### PR TITLE
Feature/148098651/user can update own profile

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
   },
   "rules": {
     "one-var": 0,
+    "max-len": [1, 80, 2],
     "one-var-declaration-per-line": 0,
     "new-cap": 0,
     "consistent-return": 0,

--- a/client/src/components/DashboardContainer.jsx
+++ b/client/src/components/DashboardContainer.jsx
@@ -11,6 +11,8 @@ import UpdateUserPage from './UpdateUserPage';
 import UsersPage from './UsersPage';
 import UpdateDocument from './UpdateDocument';
 
+// TODO: Auto logout a user when you get errors like NonExistentUserError, InvalidTokenError etc.
+
 /**
  * DashboardContainer - Renders the dashboard.
  */
@@ -153,14 +155,25 @@ class DashboardContainer extends React.Component {
               Home
             </NavLink>
           </li>
+          <li key={uuid.v4()}>
+            <NavLink
+              exact
+              to={`/dashboard/profile/${this.props.user.user.id}`}
+              activeClassName="teal lighten-2 white-text disabled"
+            >
+              <Icon left>person_outline</Icon>
+              Update profile
+            </NavLink>
+          </li>
           <SideNavItem divider />
           {this.getAdminSection()}
           <SideNavItem waves onClick={this.logout} icon="input">Logout</SideNavItem>
         </SideNav>
 
         <Switch>
-          <Route path="/dashboard/updateUser" render={() => <UpdateUserPage {...this.props} />} />
+          <Route path="/dashboard/profile" render={() => <UpdateUserPage {...this.props} />} />
           <Route path="/dashboard/users" render={() => <UsersPage {...this.props} />} />
+          <Route path="/dashboard/updateUser" render={() => <UpdateUserPage {...this.props} />} />
           <Route exact path="*" render={() => <DashboardPage {...this.props} />} />
         </Switch>
       </div>

--- a/client/src/components/DashboardContainer.jsx
+++ b/client/src/components/DashboardContainer.jsx
@@ -92,13 +92,21 @@ class DashboardContainer extends React.Component {
    * null if nothing is to be rendered.
    */
   render() {
-    if (!this.props.user.isLoggedIn) {
-      return <Redirect to="/" />;
+    if (this.props.user.status === 'deletedUser'
+      && this.props.user.user.id === this.props.user.deletedUserId) {
+      window.localStorage.clear();
+      $('#deleteAccountModal').modal('close');
+      Materialize.toast(this.props.user.statusMessage, 5000);
+      return <Redirect to="/dashboard" />;
     }
 
     if (this.props.documents.status === 'invalidTokenError') {
       window.localStorage.clear();
       Materialize.toast(this.props.documents.statusMessage, 5000);
+      return <Redirect to="/" />;
+    }
+
+    if (!this.props.user.isLoggedIn) {
       return <Redirect to="/" />;
     }
 

--- a/client/src/components/DeleteUserPage.jsx
+++ b/client/src/components/DeleteUserPage.jsx
@@ -56,7 +56,7 @@ class DeleteUserPage extends Component {
   attemptToDeleteUser(event) {
     event.preventDefault();
 
-    if (!this.hasConhasConfirmedDeletion()) {
+    if (!this.hasConfirmedDeletion()) {
       return;
     }
 

--- a/client/src/components/UpdateUserPage.jsx
+++ b/client/src/components/UpdateUserPage.jsx
@@ -404,16 +404,6 @@ class UpdateUserPage extends Component {
    * null if nothing is to be rendered.
    */
   render() {
-    // TODO: Log out a user when he/she deletes his/her own account.
-    if (this.state.targetUser) {
-      if (this.state.targetUser.id === this.props.user.deletedUserId
-        && this.props.user.status === 'deletedUser') {
-        $('#deleteAccountModal').modal('close');
-        Materialize.toast(this.props.user.statusMessage, 5000);
-        return <Redirect to="/dashboard" />;
-      }
-    }
-
     return (
       <div className="scrollable-page update-user-page">
         {this.showUpdateForm()}

--- a/client/src/components/UpdateUserPage.jsx
+++ b/client/src/components/UpdateUserPage.jsx
@@ -270,7 +270,10 @@ class UpdateUserPage extends Component {
    */
   showDeleteAccountSection() {
     if (this.state.targetUser) {
-      if (this.props.user.user.roleId > 0 && this.state.targetUser.id !== this.props.user.user.id) {
+      if (
+        (this.props.user.user.roleId < 1) ||
+        (this.props.user.user.roleId > 0 && this.state.targetUser.id !== this.props.user.user.id)
+      ) {
         return (
           <div>
             {/* TODO: If a user deletes his or her own account, log him/her out immediately. */}

--- a/client/src/reducers/documentsReducer.js
+++ b/client/src/reducers/documentsReducer.js
@@ -10,7 +10,9 @@ import {
   CREATE_DOCUMENT_FULFILLED,
   DELETE_DOCUMENT_PENDING,
   DELETE_DOCUMENT_REJECTED,
-  DELETE_DOCUMENT_FULFILLED
+  DELETE_DOCUMENT_FULFILLED,
+
+  LOGOUT_PENDING
 } from '../constants';
 
 /**
@@ -23,6 +25,11 @@ import {
 export default function documentsReducer(state, action) {
   const newState = Object.assign({}, state);
   switch (action.type) {
+    case LOGOUT_PENDING:
+      newState.documents = [];
+      newState.count = 0;
+      break;
+
     case FETCH_USER_DOCUMENTS_PENDING:
     case FETCH_DOCUMENTS_PENDING:
       newState.status = 'fetchingDocuments';

--- a/client/src/reducers/userReducer.js
+++ b/client/src/reducers/userReducer.js
@@ -129,6 +129,11 @@ export default function userReducer(state, action) {
         user.username !== action.payload.users[0].username
       );
       newState.deletedUserId = action.payload.users[0].id;
+      if (action.payload.users[0].id === state.user.id) {
+        newState.isLoggedIn = false;
+        newState.isLoggingIn = false;
+        newState.isLoggingOut = false;
+      }
       break;
 
     default:

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ import app from './server/app';
 dotenv.config();
 const port = process.env.PORT || 5000;
 
+// TODO: Do we need to import initSequelize and run sequelize.sync() first?
 app.listen(port, () => {
   console.log('Node app is running on port', port);
 });

--- a/server/controllers/DocumentsController.js
+++ b/server/controllers/DocumentsController.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
-import Document from '../models/Document';
-import User from '../models/User';
+import { Document, User } from '../models/';
 import getLimitAndOffset from '../util/getLimitAndOffset';
 
 /**

--- a/server/controllers/DocumentsController.js
+++ b/server/controllers/DocumentsController.js
@@ -173,15 +173,21 @@ export default class DocumentsController {
 
     Document
       .findAll({
-        // TODO: Add restrictions for 'role' and admin access of private
-        // files, using hasMany(), belongsTo() etc.
+        include: [{ model: User, attributes: ['id', 'firstName', 'lastName', 'username', 'roleId'] }],
         where: {
           $or: [
             { access: 'public' },
             { authorId: id },
+            {
+              $and: [
+                { access: 'role' },
+                { '$User.roleId$': req.decodedUserProfile.roleId }
+              ]
+            }
           ]
         },
         attributes: ['id', 'title', 'content', 'access', 'categories', 'tags', 'createdAt', 'authorId'],
+        order: [['createdAt', 'DESC']],
         limit,
         offset
       })

--- a/server/controllers/DocumentsController.js
+++ b/server/controllers/DocumentsController.js
@@ -26,7 +26,7 @@ export default class DocumentsController {
     const categories = reqBody.categories;
     const tags = reqBody.tags;
 
-    const createdBy = req.decodedUserProfile.id;
+    const authorId = req.decodedUserProfile.id;
 
     const newDocument = {
       title,
@@ -34,7 +34,7 @@ export default class DocumentsController {
       access,
       categories,
       tags,
-      createdBy
+      authorId
     };
     Document
       .create(newDocument)
@@ -50,7 +50,7 @@ export default class DocumentsController {
               categories: createdDocument.categories,
               tags: createdDocument.tags,
               createdAt: createdDocument.createdAt,
-              createdBy: createdDocument.createdBy
+              authorId: createdDocument.authorId
             }]
           });
       });
@@ -92,7 +92,7 @@ export default class DocumentsController {
         where: {
           id: documentId
         },
-        attributes: ['id', 'title', 'content', 'access', 'categories', 'tags', 'createdAt', 'createdBy']
+        attributes: ['id', 'title', 'content', 'access', 'categories', 'tags', 'createdAt', 'authorId']
       })
       .then((foundDocument) => {
         if (foundDocument) {
@@ -106,7 +106,7 @@ export default class DocumentsController {
           }
 
           if (foundDocument.access === 'private') {
-            if (id === foundDocument.createdBy || roleId > 0) {
+            if (id === foundDocument.authorId || roleId > 0) {
               res.status(200)
                 .json({
                   message: 'Document found.',
@@ -126,7 +126,7 @@ export default class DocumentsController {
             User
               .findOne({
                 where: {
-                  id: foundDocument.createdBy
+                  id: foundDocument.authorId
                 },
                 attributes: ['id', 'roleId']
               })
@@ -179,10 +179,10 @@ export default class DocumentsController {
         where: {
           $or: [
             { access: 'public' },
-            { createdBy: id },
+            { authorId: id },
           ]
         },
-        attributes: ['id', 'title', 'content', 'access', 'categories', 'tags', 'createdAt', 'createdBy'],
+        attributes: ['id', 'title', 'content', 'access', 'categories', 'tags', 'createdAt', 'authorId'],
         limit,
         offset
       })
@@ -241,7 +241,7 @@ export default class DocumentsController {
       .then((foundDocument) => {
         if (foundDocument) {
           const updaterId = userProfile.id;
-          if (foundDocument.createdBy === updaterId) {
+          if (foundDocument.authorId === updaterId) {
             const document = {};
             if (documentUpdate.title) {
               document.title = documentUpdate.title;
@@ -279,7 +279,7 @@ export default class DocumentsController {
                       categories: updatedDocument.categories,
                       tags: updatedDocument.tags,
                       createdAt: updatedDocument.createdAt,
-                      createdBy: updatedDocument.createdBy,
+                      authorId: updatedDocument.authorId,
                     }]
                   });
               });
@@ -335,7 +335,7 @@ export default class DocumentsController {
       .then((foundDocument) => {
         if (foundDocument) {
           const deleterId = userProfile.id;
-          if (foundDocument.createdBy === deleterId || userProfile.roleId > 0) {
+          if (foundDocument.authorId === deleterId || userProfile.roleId > 0) {
             Document
               .destroy({
                 where: {

--- a/server/controllers/SearchController.js
+++ b/server/controllers/SearchController.js
@@ -91,17 +91,24 @@ export default class SearchController {
       return;
     }
 
-    // TODO: Add code for when access === 'role'.
     Document
       .findAll({
+        include: [{ model: User, attributes: ['id', 'firstName', 'lastName', 'username', 'roleId'] }],
         where: {
           title: { $iLike: `%${documentTitleQuery}%` },
           $or: [
             { access: 'public' },
-            { access: 'private', authorId: userProfile.id }
+            { access: 'private', authorId: userProfile.id },
+            {
+              $and: [
+                { access: 'role' },
+                { '$User.roleId': req.decodedUserProfile.roleId }
+              ]
+            }
           ]
         },
         attributes: ['id', 'title', 'content', 'access', 'categories', 'tags', 'createdAt', 'authorId'],
+        order: [['createdAt', 'DESC']],
         limit,
         offset
       })

--- a/server/controllers/SearchController.js
+++ b/server/controllers/SearchController.js
@@ -1,7 +1,5 @@
-import Document from '../models/Document';
-import User from '../models/User';
+import { Document, User } from '../models/';
 import getLimitAndOffset from '../util/getLimitAndOffset';
-
 
 /**
  * Defines the controller for the /search route.

--- a/server/controllers/SearchController.js
+++ b/server/controllers/SearchController.js
@@ -100,10 +100,10 @@ export default class SearchController {
           title: { $iLike: `%${documentTitleQuery}%` },
           $or: [
             { access: 'public' },
-            { access: 'private', createdBy: userProfile.id }
+            { access: 'private', authorId: userProfile.id }
           ]
         },
-        attributes: ['id', 'title', 'content', 'access', 'categories', 'tags', 'createdAt', 'createdBy'],
+        attributes: ['id', 'title', 'content', 'access', 'categories', 'tags', 'createdAt', 'authorId'],
         limit,
         offset
       })

--- a/server/controllers/SearchController.js
+++ b/server/controllers/SearchController.js
@@ -102,7 +102,7 @@ export default class SearchController {
             {
               $and: [
                 { access: 'role' },
-                { '$User.roleId': req.decodedUserProfile.roleId }
+                { '$User.roleId$': req.decodedUserProfile.roleId }
               ]
             }
           ]

--- a/server/controllers/UsersController.js
+++ b/server/controllers/UsersController.js
@@ -459,7 +459,8 @@ export default class UsersController {
           if (userCount > 0) {
             res.status(200)
               .json({
-                message: 'It\'s a pity, but you successfully deleted that account.'
+                message: 'We hate to see you go! But your account was successfully deleted.',
+                users: [req.decodedUserProfile]
               });
           } else {
             res.status(404)

--- a/server/controllers/UsersController.js
+++ b/server/controllers/UsersController.js
@@ -565,9 +565,9 @@ export default class UsersController {
           Document
             .findAll({
               where: {
-                createdBy: id
+                authorId: id
               },
-              attributes: ['id', 'title', 'content', 'access', 'categories', 'tags', 'createdAt', 'createdBy'],
+              attributes: ['id', 'title', 'content', 'access', 'categories', 'tags', 'createdAt', 'authorId'],
               order: [['createdAt', 'DESC']],
               returning: true
             })

--- a/server/controllers/UsersController.js
+++ b/server/controllers/UsersController.js
@@ -3,17 +3,13 @@ import dotenv from 'dotenv';
 import JWT from 'jsonwebtoken';
 
 import { DEFAULT_ROLE_ID } from '../constants';
-import Document from '../models/Document';
-import User from '../models/User';
+import { Document, User } from '../models/';
 import getLimitAndOffset from '../util/getLimitAndOffset';
 import isValidEmail from '../util/isValidEmail';
 import isValidName from '../util/isValidName';
 import isValidPassword from '../util/isValidPassword';
 
 dotenv.config();
-
-// TODO: De-link getUserDocuments, getUser and getAllUsers, at least in
-// the JSDoc of each.
 
 /**
  * Defines the controller for the /users route.

--- a/server/middleware/validateToken.js
+++ b/server/middleware/validateToken.js
@@ -1,5 +1,6 @@
 import JWT from 'jsonwebtoken';
-import User from '../models/User';
+import { User } from '../models/';
+
 
 /**
  * Validates the token supplied to any HTTP request to a given route, before

--- a/server/migrations/03-Document.js
+++ b/server/migrations/03-Document.js
@@ -39,7 +39,7 @@ module.exports = {
         type: Sequelize.STRING,
         allowNull: false,
       },
-      createdBy: {
+      authorId: {
         type: Sequelize.INTEGER,
         allowNull: false,
         onUpdate: 'CASCADE',

--- a/server/models/Document.js
+++ b/server/models/Document.js
@@ -26,8 +26,8 @@ const Document = sequelize.define('Document', {
   tags: {
     type: Sequelize.STRING
   },
-  createdBy: {
-    type: Sequelize.STRING
+  authorId: {
+    type: Sequelize.INTEGER
   },
   createdAt: {
     type: Sequelize.DATE

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,0 +1,23 @@
+import Role from './Role';
+import User from './User';
+import Document from './Document';
+
+Role.hasMany(User, {
+  foreignKey: 'roleId'
+});
+
+User.belongsTo(Role, {
+  foreignKey: 'roleId'
+});
+
+User.hasMany(Document, {
+  foreignKey: 'authorId'
+});
+
+Document.belongsTo(User, {
+  foreignKey: 'authorId'
+});
+
+export { Role };
+export { User };
+export { Document };

--- a/server/routes/usersRoute.js
+++ b/server/routes/usersRoute.js
@@ -18,7 +18,7 @@ const usersRouter = express.Router();
  *        - access
  *        - categories
  *        - tags
- *        - createdBy
+ *        - authorId
  *     properties:
  *       title:
  *         type: string
@@ -30,7 +30,7 @@ const usersRouter = express.Router();
  *         type: string
  *       tags:
  *         type: string
- *       createdBy:
+ *       authorId:
  *         type: string
  *   Document:
  *     allOf:

--- a/server/tests/controllers/createDocumentSpec.js
+++ b/server/tests/controllers/createDocumentSpec.js
@@ -4,7 +4,7 @@ import JWT from 'jsonwebtoken';
 import dotenv from 'dotenv';
 import uuid from 'uuid';
 import { DEFAULT_REGULAR_USER } from '../../constants';
-import Document from '../../models/Document';
+import { Document } from '../../models/';
 import app from '../../app';
 
 dotenv.config();

--- a/server/tests/controllers/createDocumentSpec.js
+++ b/server/tests/controllers/createDocumentSpec.js
@@ -20,7 +20,7 @@ describe('When POST\'ed to, the /api/documents endpoint', () => {
     access: 'public',
     categories: 'quuz',
     tags: 'qlat',
-    createdBy: 0
+    authorId: 0
   };
 
   after('Remove the sample document used in this suite\'s specs', (done) => {

--- a/server/tests/controllers/deleteDocumentSpec.js
+++ b/server/tests/controllers/deleteDocumentSpec.js
@@ -18,7 +18,7 @@ describe('When it gets a DELETE request, the /api/documents endpoint', () => {
     access: 'public',
     categories: 'quuz',
     tags: 'qlat',
-    createdBy: 0
+    authorId: 0
   };
 
   let id;

--- a/server/tests/controllers/deleteDocumentSpec.js
+++ b/server/tests/controllers/deleteDocumentSpec.js
@@ -3,7 +3,7 @@ import JWT from 'jsonwebtoken';
 import dotenv from 'dotenv';
 import uuid from 'uuid';
 import { DEFAULT_REGULAR_USER } from '../../constants';
-import Document from '../../models/Document';
+import { Document } from '../../models/';
 import app from '../../app';
 
 dotenv.config();

--- a/server/tests/controllers/deleteUserSpec.js
+++ b/server/tests/controllers/deleteUserSpec.js
@@ -1,4 +1,5 @@
 import supertest from 'supertest';
+import chai from 'chai';
 import dotenv from 'dotenv';
 import bcryptjs from 'bcryptjs';
 import JWT from 'jsonwebtoken';
@@ -8,6 +9,7 @@ import app from '../../app';
 dotenv.config();
 
 const request = supertest(app);
+const expect = chai.expect;
 const deleteUserEndpoint = '/api/users';
 
 describe('When it receives a DELETE request, the /api/users/<id> endpoint', () => {
@@ -118,8 +120,14 @@ describe('When it receives a DELETE request, the /api/users/<id> endpoint', () =
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200)
-      .expect({
-        message: 'It\'s a pity, but you successfully deleted that account.'
-      }, done);
+      .end((err, res) => {
+        if (err) done(err);
+
+        expect(res.body.message).to.equal('We hate to see you go! But your account was successfully deleted.');
+        expect(Array.isArray(res.body.users)).to.equal(true);
+        const deletedUser = res.body.users[0];
+        expect(deletedUser.username).to.equal(dummyUser.username);
+        done();
+      });
   });
 });

--- a/server/tests/controllers/deleteUserSpec.js
+++ b/server/tests/controllers/deleteUserSpec.js
@@ -2,7 +2,7 @@ import supertest from 'supertest';
 import dotenv from 'dotenv';
 import bcryptjs from 'bcryptjs';
 import JWT from 'jsonwebtoken';
-import User from '../../models/User';
+import { User } from '../../models/';
 import app from '../../app';
 
 dotenv.config();

--- a/server/tests/controllers/getAllUsersSpec.js
+++ b/server/tests/controllers/getAllUsersSpec.js
@@ -3,7 +3,7 @@ import dotenv from 'dotenv';
 import JWT from 'jsonwebtoken';
 import bcryptjs from 'bcryptjs';
 import chai from 'chai';
-import User from '../../models/User';
+import { User } from '../../models/';
 import app from '../../app';
 
 dotenv.config();

--- a/server/tests/controllers/getUserDocumentsSpec.js
+++ b/server/tests/controllers/getUserDocumentsSpec.js
@@ -2,7 +2,7 @@ import supertest from 'supertest';
 import dotenv from 'dotenv';
 import JWT from 'jsonwebtoken';
 import chai from 'chai';
-import Document from '../../models/Document';
+import { Document } from '../../models/';
 import app from '../../app';
 
 dotenv.config();

--- a/server/tests/controllers/getUserDocumentsSpec.js
+++ b/server/tests/controllers/getUserDocumentsSpec.js
@@ -34,7 +34,7 @@ describe('When it receives a GET request, the /api/users/<id>/documents endpoint
     access: 'public',
     categories: 'random',
     tags: 'random',
-    createdBy: 0
+    authorId: 0
   };
 
   before('Create a dummy document', (done) => {

--- a/server/tests/controllers/getUserSpec.js
+++ b/server/tests/controllers/getUserSpec.js
@@ -3,7 +3,7 @@ import dotenv from 'dotenv';
 import JWT from 'jsonwebtoken';
 import bcryptjs from 'bcryptjs';
 import chai from 'chai';
-import User from '../../models/User';
+import { User } from '../../models/';
 import app from '../../app';
 
 dotenv.config();

--- a/server/tests/controllers/searchDocumentsSpec.js
+++ b/server/tests/controllers/searchDocumentsSpec.js
@@ -4,7 +4,7 @@ import JWT from 'jsonwebtoken';
 import dotenv from 'dotenv';
 import uuid from 'uuid';
 import { DEFAULT_REGULAR_USER } from '../../constants';
-import Document from '../../models/Document';
+import { Document } from '../../models/';
 import app from '../../app';
 
 dotenv.config();

--- a/server/tests/controllers/searchDocumentsSpec.js
+++ b/server/tests/controllers/searchDocumentsSpec.js
@@ -20,7 +20,7 @@ describe('When it receives a GET request, the /api/search/documents endpoint', (
     access: 'public',
     categories: 'quuz',
     tags: 'qlat',
-    createdBy: 0
+    authorId: 0
   };
 
   before('Create the sample document to be used in this suite\'s specs', (done) => {

--- a/server/tests/controllers/searchUsersSpec.js
+++ b/server/tests/controllers/searchUsersSpec.js
@@ -3,9 +3,7 @@ import chai from 'chai';
 import bcryptjs from 'bcryptjs';
 import JWT from 'jsonwebtoken';
 import dotenv from 'dotenv';
-import uuid from 'uuid';
-import Document from '../../models/Document';
-import User from '../../models/User';
+import { User } from '../../models/';
 import app from '../../app';
 
 dotenv.config();

--- a/server/tests/controllers/signUpSpec.js
+++ b/server/tests/controllers/signUpSpec.js
@@ -1,7 +1,7 @@
 import supertest from 'supertest';
 import chai from 'chai';
 import dotenv from 'dotenv';
-import User from '../../models/User';
+import { User } from '../../models/';
 import app from '../../app';
 
 dotenv.config();

--- a/server/tests/controllers/updateDocumentSpec.js
+++ b/server/tests/controllers/updateDocumentSpec.js
@@ -4,7 +4,7 @@ import JWT from 'jsonwebtoken';
 import dotenv from 'dotenv';
 import uuid from 'uuid';
 import { DEFAULT_REGULAR_USER } from '../../constants';
-import Document from '../../models/Document';
+import { Document } from '../../models/';
 import app from '../../app';
 
 dotenv.config();

--- a/server/tests/controllers/updateDocumentSpec.js
+++ b/server/tests/controllers/updateDocumentSpec.js
@@ -20,7 +20,7 @@ describe('When PUT to, the /api/documents endpoint', () => {
     access: 'public',
     categories: 'quuz',
     tags: 'qlat',
-    createdBy: 0
+    authorId: 0
   };
 
   let id;

--- a/server/tests/controllers/updateUserProfileSpec.js
+++ b/server/tests/controllers/updateUserProfileSpec.js
@@ -3,7 +3,7 @@ import chai from 'chai';
 import JWT from 'jsonwebtoken';
 import bcryptjs from 'bcryptjs';
 import dotenv from 'dotenv';
-import User from '../../models/User';
+import { User } from '../../models/';
 import app from '../../app';
 
 dotenv.config();

--- a/server/tests/models/DocumentSpec.js
+++ b/server/tests/models/DocumentSpec.js
@@ -1,7 +1,7 @@
 import chai from 'chai';
 import dotenv from 'dotenv';
 import uuid from 'uuid';
-import Document from '../../models/Document';
+import { Document } from '../../models/';
 
 dotenv.config();
 const expect = chai.expect;

--- a/server/tests/models/DocumentSpec.js
+++ b/server/tests/models/DocumentSpec.js
@@ -13,7 +13,7 @@ describe('The Document model', () => {
     access: 'public',
     categories: 'foo',
     tags: 'bar',
-    createdBy: 0
+    authorId: 0
   };
 
   const completeNewDocument = {
@@ -22,7 +22,7 @@ describe('The Document model', () => {
     access: 'public',
     categories: 'quuz',
     tags: 'qlat',
-    createdBy: 0
+    authorId: 0
   };
 
   before('Create a sample document', (done) => {
@@ -51,7 +51,7 @@ describe('The Document model', () => {
       access: 'public',
       categories: 'foo',
       tags: 'bar',
-      createdBy: 0
+      authorId: 0
     };
     Document.create(noTitle)
       .catch((errors) => {
@@ -69,7 +69,7 @@ describe('The Document model', () => {
       access: 'public',
       categories: 'foo',
       tags: 'bar',
-      createdBy: 0
+      authorId: 0
     };
     Document.create(noContent)
       .catch((errors) => {
@@ -87,7 +87,7 @@ describe('The Document model', () => {
       content: 'Lorem ipsum',
       access: 'public',
       tags: 'bar',
-      createdBy: 0
+      authorId: 0
     };
     Document.create(noCategories)
       .catch((errors) => {
@@ -105,7 +105,7 @@ describe('The Document model', () => {
       content: 'Lorem ipsum',
       access: 'public',
       categories: 'foo',
-      createdBy: 0
+      authorId: 0
     };
     Document.create(noTags)
       .catch((errors) => {
@@ -124,7 +124,7 @@ describe('The Document model', () => {
       access: '',
       categories: 'foo',
       tags: 'bar',
-      createdBy: 0
+      authorId: 0
     };
     Document.create(noAccessTypes)
       .catch((errors) => {
@@ -145,7 +145,7 @@ describe('The Document model', () => {
       access: 'random',
       categories: 'foo',
       tags: 'bar',
-      createdBy: 0
+      authorId: 0
     };
     Document.create(invalidAccessType)
       .catch((errors) => {
@@ -158,34 +158,34 @@ describe('The Document model', () => {
       });
   });
 
-  it('should reject the creation of documents that do NOT have a' +
-    ' createdBy (i.e author id)', (done) => {
-    const noCreatedBy = {
+  it('should reject the creation of documents that do NOT have an' +
+    ' authorId', (done) => {
+    const noAuthorId = {
       title: 'Spalaxicon1',
       content: 'Lorem ipsum',
       access: 'public',
       categories: 'foo',
       tags: 'bar'
     };
-    Document.create(noCreatedBy)
+    Document.create(noAuthorId)
       .catch((errors) => {
-        const expectedMessage = 'null value in column "createdBy" violates not-null constraint';
+        const expectedMessage = 'null value in column "authorId" violates not-null constraint';
         expect(errors.name).to.equal('SequelizeDatabaseError');
         expect(errors.message).to.equal(expectedMessage);
         done();
       });
   });
 
-  it('should reject the creation of documents whose createdBy (i.e author id) is NOT an integer', (done) => {
-    const invalidCreatedBy = {
+  it('should reject the creation of documents whose authorId (i.e author id) is NOT an integer', (done) => {
+    const invalidAuthorId = {
       title: 'Spalaxicon1',
       content: 'Lorem ipsum',
       access: 'public',
       categories: 'foo',
       tags: 'bar',
-      createdBy: 'quux'
+      authorId: 'quux'
     };
-    Document.create(invalidCreatedBy)
+    Document.create(invalidAuthorId)
       .catch((errors) => {
         const expectedMessage = 'invalid input syntax for integer: "quux"';
         expect(errors.name).to.equal('SequelizeDatabaseError');
@@ -194,19 +194,19 @@ describe('The Document model', () => {
       });
   });
 
-  it('should reject the creation of documents whose createdBy (i.e author id) is NOT in the User model', (done) => {
+  it('should reject the creation of documents whose authorId (i.e author id) is NOT in the User model', (done) => {
     const nonExistentUser = {
       title: 'Spalaxicon1',
       content: 'Lorem ipsum',
       access: 'public',
       categories: 'foo',
       tags: 'bar',
-      createdBy: 6543210
+      authorId: 6543210
     };
     Document.create(nonExistentUser)
       .catch((errors) => {
         const expectedMessage = 'insert or update on table "Document" violates' +
-        ' foreign key constraint "Document_createdBy_fkey"';
+        ' foreign key constraint "Document_authorId_fkey"';
         expect(errors.name).to.equal('SequelizeForeignKeyConstraintError');
         expect(errors.message).to.equal(expectedMessage);
         done();

--- a/server/tests/models/RoleSpec.js
+++ b/server/tests/models/RoleSpec.js
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import dotenv from 'dotenv';
-import Role from '../../models/Role';
+import { Role } from '../../models/';
 
 dotenv.config();
 const expect = chai.expect;

--- a/server/tests/models/UserSpec.js
+++ b/server/tests/models/UserSpec.js
@@ -1,7 +1,7 @@
 import chai from 'chai';
 import bcryptjs from 'bcryptjs';
 import dotenv from 'dotenv';
-import User from '../../models/User';
+import { User } from '../../models/';
 
 dotenv.config();
 const expect = chai.expect;


### PR DESCRIPTION
#### What does this PR do?

This PR enables users to update their own profile (including admin users). It also enables them to delete their account (except admin users).

#### Description of task to be completed

Enable users to update their own profile or delete their own account.

#### How should this be manually tested?

- Follow the instructions stated in this project's README to set up your local instance of this app.

- Consequently, you should have sign up for a new account.

- In the app menu, you will see an option to tagged 'Update profile'. Click on it.

- You should now see one form for updating your profile. There should also be one below it that you can use to delete your account.

- If you sign in with an admin account, then you should see the update form ONLY.

#### Any background context you want to provide?

N/A

#### What are the relevant Pivotal Tracker stories?

148098651

#### Screenshots
<img width="1270" alt="screen shot 2017-07-07 at 10 09 28 am" src="https://user-images.githubusercontent.com/26963575/27951343-79b72d36-62fc-11e7-8a4a-72d8b2c50491.png">




